### PR TITLE
feat(api): add get_stream_manifest for video streaming

### DIFF
--- a/gpmc/api.py
+++ b/gpmc/api.py
@@ -1246,3 +1246,37 @@ class Api:
 
         decoded_message, _ = decode_message(response.content)
         return decoded_message
+
+    def get_stream_manifest(self, media_key: str, protocol: Literal["hls", "dash"] = "hls", content_version: int | None = None) -> str:
+        """
+        Fetch the streaming manifest for a given media key.
+
+        Args:
+            media_key: Target video item's media key.
+            protocol: The streaming protocol format to request. Must be either
+                'hls' or 'dash'. Defaults to 'hls' if not specified.
+            content_version: Specifies content version. Without it manifest will represent the original, not edited content.
+
+        Returns:
+            str: The streaming manifest content.
+        """
+        headers = {
+            "accept-encoding": "gzip",
+            "User-Agent": self.user_agent,
+            "Authorization": f"Bearer {self.bearer_token}",
+        }
+
+        url = f"https://lh3.googleusercontent.com/p/{media_key}%3Dmm%2C{protocol}-vm"
+
+        if content_version:
+            url += f"-iv{content_version}"
+
+        with self._new_session() as session:
+            response = session.post(
+                url,
+                headers=headers,
+                timeout=self.timeout,
+            )
+
+        response.raise_for_status()
+        return response.text

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -11,6 +11,11 @@ class TestUpload(unittest.TestCase):
         self.directory_path = "C:/Users/admin/Pictures"
         self.mkv_file_path = "media/sample_640x360.mkv"
         self.client = Client()
+    def test_get_manifest_content(self):
+        """Test get manifest."""
+        output = self.client.api.get_stream_manifest("AF1QipMZCIEXnkW7cyj7UJXZ_sL-GAo3yAlQTyfHgnX3", protocol="hls")
+        print(output)
+
     def test_restore_from_trash(self):
         """Test restore from trash."""
         dedup_key = utils.urlsafe_base64(self.image_sha1_hash_b64)


### PR DESCRIPTION
## Summary
- Adds `get_stream_manifest()` method to fetch HLS/DASH streaming manifests for videos
- Supports both `hls` and `dash` protocols
- Optional `content_version` parameter for edited content