### PR TITLE
chore: normalize project name to GPMC

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# google_photos_mobile_client
+# GPMC
 
-Google Photos client based on reverse engineered mobile API.
+Google Photos Mobile Client based on the reverse-engineered mobile API.
 
 ---
 
@@ -26,7 +26,7 @@ Google Photos client based on reverse engineered mobile API.
 Run the command:
 
 ```bash
-pip install https://github.com/xob0t/google_photos_mobile_client/archive/refs/heads/main.zip --force-reinstall
+pip install https://github.com/xob0t/gpmc/archive/refs/heads/main.zip --force-reinstall
 ```
 
 ## Example Usage

--- a/gpmc/client.py
+++ b/gpmc/client.py
@@ -94,11 +94,11 @@ class _ProgressReader:
 
 
 class Client:
-    """Google Photos client based on reverse engineered mobile API."""
+    """Google Photos Mobile Client based on the reverse-engineered mobile API."""
 
     def __init__(self, auth_data: str = "", proxy: str = "", language: str = "", timeout: int = DEFAULT_TIMEOUT, log_level: LogLevel = "INFO") -> None:
         """
-        Google Photos client based on reverse engineered mobile API.
+        Google Photos Mobile Client based on the reverse-engineered mobile API.
 
         Args:
             auth_data: Google authentication data string. If not provided, will attempt to use

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ packages = ["gpmc"]
 [project]
 name = "gpmc"
 version = "0.8.0"
-description = "Google Photos client based on reverse engineered mobile API."
+description = "Google Photos Mobile Client based on the reverse-engineered mobile API."
 authors = [{ name = "xob0t" }]
 readme = "README.md"
 license = "MIT"
@@ -47,7 +47,7 @@ select = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/xob0t/google_photos_mobile_client"
+Homepage = "https://github.com/xob0t/gpmc"
 
 [project.scripts]
 gpmc = "gpmc.cli:main"


### PR DESCRIPTION
## What changed

- Brand the project consistently as `GPMC` in the README, package metadata, and client documentation.
- Point repository and installation URLs at the canonical `xob0t/gpmc` location.
- Rename `readme.md` to `README.md` so the filename matches `pyproject.toml` on case-sensitive systems.

## Why

This establishes `gpmc` as the single name for the repository, Python distribution, import package, and CLI before automated PyPI publishing is introduced.

## Merge prerequisite

Rename the GitHub repository from `google_photos_mobile_client` to `gpmc` in repository settings before marking this PR ready or merging it. Until then, the new canonical URLs intentionally point at the future repository location.

## Validation

- `python -m ruff check .`
- `uv build`
- `git diff --check`

No regression tests were run, per repository instructions.