### PR TITLE
fix: decode media keys as strings to avoid dict misparse

### DIFF
--- a/gpmc/api.py
+++ b/gpmc/api.py
@@ -189,7 +189,7 @@ class Api:
             )
         response.raise_for_status()
 
-        decoded_message, _ = decode_message(response.content)
+        decoded_message, _ = decode_message(response.content, message_types.FIND_REMOTE_MEDIA_BY_HASH_RESPONSE)  # type: ignore
         media_key = decoded_message["1"].get("2", {}).get("2", {}).get("1", None)
         return media_key
 
@@ -306,7 +306,7 @@ class Api:
                 timeout=self.timeout,
             )
         response.raise_for_status()
-        decoded_message, _ = decode_message(response.content)
+        decoded_message, _ = decode_message(response.content, message_types.COMMIT_UPLOAD_RESPONSE)  # type: ignore
         try:
             media_key = decoded_message["1"]["3"]["1"]
         except KeyError as e:
@@ -440,7 +440,7 @@ class Api:
             )
         response.raise_for_status()
 
-        decoded_message, _ = decode_message(response.content)
+        decoded_message, _ = decode_message(response.content, message_types.CREATE_ALBUM_RESPONSE)  # type: ignore
         return decoded_message["1"]["1"]
 
     def add_media_to_album(self, album_media_key: str, media_keys: Sequence[str]) -> dict:

--- a/gpmc/message_types.py
+++ b/gpmc/message_types.py
@@ -2196,3 +2196,19 @@ RESTORE_FROM_TRASH = {
 LIB_STATE_RESPONSE_FIX = {
     "1": {"type": "message", "message_typedef": {"2": {"type": "message", "message_typedef": {"2": {"type": "message", "message_typedef": {"4": {"type": "string"}}}}}}},
 }
+
+# Media keys are base64-ish strings whose raw bytes occasionally parse as a valid submessage.
+# Without an explicit typedef blackboxprotobuf prefers the message interpretation and returns a
+# dict instead of the key, which later blows up in encode_message. Pinning the field to `string`
+# forces the correct interpretation. See https://github.com/xob0t/gpmc/issues/80
+FIND_REMOTE_MEDIA_BY_HASH_RESPONSE = {
+    "1": {"type": "message", "message_typedef": {"2": {"type": "message", "message_typedef": {"2": {"type": "message", "message_typedef": {"1": {"type": "string"}}}}}}},
+}
+
+COMMIT_UPLOAD_RESPONSE = {
+    "1": {"type": "message", "message_typedef": {"3": {"type": "message", "message_typedef": {"1": {"type": "string"}}}}},
+}
+
+CREATE_ALBUM_RESPONSE = {
+    "1": {"type": "message", "message_typedef": {"1": {"type": "string"}}},
+}

--- a/tests/media_key_decode_test.py
+++ b/tests/media_key_decode_test.py
@@ -1,0 +1,64 @@
+import unittest
+
+from blackboxprotobuf import decode_message, encode_message
+
+from gpmc import message_types
+
+# A real-shaped media key whose raw bytes also parse as a valid protobuf submessage.
+# Without an explicit typedef blackboxprotobuf prefers the message interpretation and hands
+# back a dict, which later fails in encode_message with
+# `TypeError: not expecting type '<class 'dict'>'`. See issue #80.
+AMBIGUOUS_MEDIA_KEY = "AF1Qipyl_A9e_Ct-lde3sq3qC9yQZUHzPXY-ek7GNpE"
+
+
+def _encode(nesting: dict) -> bytes:
+    """Encode `nesting` with the media key stored as raw bytes, the way the api sends it."""
+
+    def build(node):
+        if isinstance(node, dict):
+            return {"type": "message", "message_typedef": {k: build(v) for k, v in node.items()}}
+        return {"type": "bytes"}
+
+    def values(node):
+        return {k: (values(v) if isinstance(v, dict) else AMBIGUOUS_MEDIA_KEY.encode()) for k, v in node.items()}
+
+    return encode_message(values(nesting), {k: build(v) for k, v in nesting.items()})  # type: ignore
+
+
+class TestMediaKeyDecoding(unittest.TestCase):
+    def test_key_is_ambiguous_without_a_typedef(self):
+        """Guard the premise: this key really does decode as a dict when the type is inferred."""
+        buf = _encode({"1": {"1": None}})
+        decoded, _ = decode_message(buf)
+        self.assertIsInstance(decoded["1"]["1"], dict)
+
+    def test_create_album_response(self):
+        buf = _encode({"1": {"1": None}})
+        decoded, _ = decode_message(buf, message_types.CREATE_ALBUM_RESPONSE)  # type: ignore
+        self.assertEqual(decoded["1"]["1"], AMBIGUOUS_MEDIA_KEY)
+
+    def test_commit_upload_response(self):
+        buf = _encode({"1": {"3": {"1": None}}})
+        decoded, _ = decode_message(buf, message_types.COMMIT_UPLOAD_RESPONSE)  # type: ignore
+        self.assertEqual(decoded["1"]["3"]["1"], AMBIGUOUS_MEDIA_KEY)
+
+    def test_find_remote_media_by_hash_response(self):
+        buf = _encode({"1": {"2": {"2": {"1": None}}}})
+        decoded, _ = decode_message(buf, message_types.FIND_REMOTE_MEDIA_BY_HASH_RESPONSE)  # type: ignore
+        self.assertEqual(decoded["1"]["2"]["2"]["1"], AMBIGUOUS_MEDIA_KEY)
+
+    def test_unrelated_fields_still_decode(self):
+        """The typedefs are partial: fields they don't declare must still come through."""
+        typedef = {
+            "1": {"type": "message", "message_typedef": {"1": {"type": "bytes"}, "2": {"type": "int"}}},
+            "9": {"type": "int"},
+        }
+        buf = encode_message({"1": {"1": AMBIGUOUS_MEDIA_KEY.encode(), "2": 7}, "9": 42}, typedef)  # type: ignore
+        decoded, _ = decode_message(buf, message_types.CREATE_ALBUM_RESPONSE)  # type: ignore
+        self.assertEqual(decoded["1"]["1"], AMBIGUOUS_MEDIA_KEY)
+        self.assertEqual(decoded["1"]["2"], 7)
+        self.assertEqual(decoded["9"], 42)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #80.

## Root cause

Media keys are base64url strings whose raw bytes occasionally parse as a valid protobuf submessage. With no typedef supplied, blackboxprotobuf prefers the message interpretation and returns a `dict` instead of the key. That dict then reaches `encode_message` when the key is added to an album:

```
TypeError: not expecting type '<class 'dict'>'
```

This is exactly the diagnosis @CarManBelarus gave in #79 and #80 — the key comes back as a dict from a failed parse in `find_remote_media_by_hash`.

Reproduced deterministically:

```
media key    : AF1Qipyl_A9e_Ct-lde3sq3qC9yQZUHzPXY-ek7GNpE
NO typedef   : dict -> {'8': [6876004254798131526, ...], '12': 863073075, ...}
WITH typedef : str  -> AF1Qipyl_A9e_Ct-lde3sq3qC9yQZUHzPXY-ek7GNpE
```

## Not a ">500 items" bug

It affects ~0.07% of media keys regardless of upload size — about 2 keys in a 2809-file upload, which matches the report. `add_media_to_album` is simply the first place a dict key reaches `encode_message`, and that call only happens past the first batch. A small unlucky upload can fail the same way in `create_album`.

## Fix

Pins the media key field to `string` in the responses for `find_remote_media_by_hash`, `commit_upload` and `create_album`.

This is the approach originally proposed in #79. I argued against it there on the basis that explicit typedefs don't override bbpb's inference — that conclusion came from testing a repeated-field scenario and generalising it to this one, which I had not tested. It was wrong, and it sent the PR down two further dead ends.

## Verification

- 5 regression tests, including a guard asserting the key really does decode as a dict without a typedef, and a check that fields the partial typedefs don't declare still decode correctly.
- Live against the API: all three paths return `str` (`commit_upload`, `find_remote_media_by_hash`, `create_album`).
- `ruff check` clean; existing tests pass.
